### PR TITLE
Fixed bug with Profaned Soul Artifact item.

### DIFF
--- a/AutoPotionMod.cs
+++ b/AutoPotionMod.cs
@@ -84,7 +84,7 @@ namespace AutoPotion
         {
             int buffType = _player.buffType[b];
             //Why does this fix the bug
-            if (buffType == 575)
+            if ((buffType == 575) || (buffType == 592))
                 return;
             orig(self, b);
             if (self == _player)

--- a/build.txt
+++ b/build.txt
@@ -1,6 +1,6 @@
 displayName = Auto Potion
 author = VoidRift
-version = 0.1.14
+version = 0.1.15
 homepage = https://github.com/VoidRift/AutoPotion
 buildIgnore = *.csproj, *.user, obj\*, bin\*, .vs\*, *.psd, *.sln, Auto Potion 1.3-legacy\*
 includePDB = true


### PR DESCRIPTION
Profaned Soul Artifact has a similar bug to Heart of the Elements. Its buff ID is 592.

Before fix:
https://user-images.githubusercontent.com/7689214/182370329-226c9505-aa9d-43ab-9f53-49db9095538d.mp4

After fix:
https://user-images.githubusercontent.com/7689214/182370465-2ea13957-8e33-46c6-88dd-b332be3560c2.mp4

Also bumped version number.

Tested Mutated Truffle aswell, an accessory that summons a minion similar to Heart of the Elements and Profaned Soul Artifact, however, it was unaffected by this bug.